### PR TITLE
Agregado contenido al espacio de precio antes y depues

### DIFF
--- a/react/components/CustomAppCalculator.tsx
+++ b/react/components/CustomAppCalculator.tsx
@@ -988,6 +988,7 @@ export const CustomAppCalculator = () =>
                   <div style={containerdiv}>
                     <div style={div1}>
                       {(porcentajeDescuento >= 1) && <span className={handles.txt_neutra_alt_bold} style={TxtPrecioAntes}>${PrecioAntes.toLocaleString('es-ES')}</span> }
+                      {(porcentajeDescuento < 1) && <span className={handles.txt_neutra_alt_bold}>&nbsp;</span> }
                     </div>
                     <div className={handles.txt_neutra_alt_bold} style={div2}>
                       {formatter.format((sellingPriceWithTax) ? Math.trunc(sellingPriceWithTax) : 0)} por M<sup>2</sup>
@@ -998,6 +999,7 @@ export const CustomAppCalculator = () =>
                   <div style={containerdiv}>
                     <div style={div1}>
                       {(porcentajeDescuento >= 1) && <span className={handles.txt_neutra_alt_bold} style={TxtPrecioAntes}>${precioAntesCaja.toLocaleString('es-ES')}</span> }
+                      {(porcentajeDescuento < 1) && <span className={handles.txt_neutra_alt_bold}>&nbsp;</span> }
                     </div>
                     <div style={div2}>
                       {formatter.format((unitMultiplier && sellingPriceWithTax) ? Math.trunc(sellingPriceWithTax * unitMultiplier ) : 0)} por Caja


### PR DESCRIPTION
Se agrega contenido al espacio de precioantes y depues cuando el descuento no existe para que mantenga el diseño y no se suba el contenido dañando la visibilidad del layout.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
